### PR TITLE
TEST-24 Added support for annotation-based JUnit method rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@ Repository of re-usable test utilities.
 
 ### Modules
 The following modules are defined:
+* internal
 * spock-all
 * junit-extensions
 * spock-extensions
 * hamcrest-extensions
 * mockito-extensions
 * failsafe-controller
+
+#### internal
+Defines a set of common utilities used internally by all other modules. This module is not meant to be depended on from outside this workspace.
 
 #### spock-all
 Defines a single pom artifact that contains all dependencies required to develop and execute Spock specifications. Simply add the following to your pom file to be able to compile and run Spock specifications:

--- a/docs/failsafe-controller.md
+++ b/docs/failsafe-controller.md
@@ -1,4 +1,4 @@
-##Testing Failsafe Code
+## Testing Failsafe Code
 
 Failsafe (from `net.jodah.failsafe`) is a really nice library that is typically used in code to repeatedly execute a given task until it succeeds or aborts. Although it can be used synchronously, it is often used asynchronously using an executor such that the tasks are executed by other threads.
 

--- a/docs/failsafe-controller.md
+++ b/docs/failsafe-controller.md
@@ -1,4 +1,4 @@
-#Testing Failsafe Code
+##Testing Failsafe Code
 
 Failsafe (from `net.jodah.failsafe`) is a really nice library that is typically used in code to repeatedly execute a given task until it succeeds or aborts. Although it can be used synchronously, it is often used asynchronously using an executor such that the tasks are executed by other threads.
 

--- a/docs/junit-extensions.md
+++ b/docs/junit-extensions.md
@@ -1,4 +1,4 @@
-##JUnit Extensions
+## JUnit Extensions
 
 JUnit extensions are divided in new method rules, method rule annotations, and test runners.
 

--- a/docs/junit-extensions.md
+++ b/docs/junit-extensions.md
@@ -1,4 +1,36 @@
-#JUnit Extensions
+##JUnit Extensions
+
+JUnit extensions are divided in new method rules, method rule annotations, and test runners.
+
+### JUnit Method Rules
+
+#### MethodRuleAnnotationProcessor
+The [MethodRuleAnnotationProcessor](../junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java) provides a JUnit4 method rule that implements a similar support to Spock extensions by allowing specification of simple JUnit method rules via the meta-annotation [ExtensionMethodRuleAnnotation](../junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java).
+
+New annotations created referencing a JUnit method rule can be used to annotate JUnit test class when the method rule should apply to all tests in that class. These anntations can also be used to annotate a particular test method if the method rule should only apply to that test method.
+
+The order these new annotations are defined in will dictate the order they will be applied from outermost to innermost.
+
+Method rules referenced in this manner will not retain any states from one test method to the next as they will be re-instantiated each time. The method rule class must define either a public constructor with a single argument of the same annotation type as the annotation that is annotated with the meta-annotation [ExtensionMethodRuleAnnotation](../junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java) or a public default constructor. Defining a constructor with the annotation as a parameter allows customization of the method rule using your own annotation.
+
+
+```
+  @RestoreSystemProperties // will apply to each test methods
+  public class MyTest {
+    @Rule public final MethodRuleAnnotationProcessor processor = new MethodRuleAnnotationProcessor();
+
+    @ClearInterruptions // will only apply to this test method
+    @Test
+    public void testSomething() throws Exception {
+    }
+
+    @Test
+    public void testSomethingElse() throws Exception {
+    }
+  }
+```
+
+The advantage of using the test runner [MethodRuleAnnotationRunner](../junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java) over the method rule [MethodRuleAnnotationProcessor](../junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java) is that it guarantees that all annotation-based rules will be considered outermost compared to any rules defined within the test class whereas the processor cannot guarantee that since it is at the mercy of JUnit in terms of how the rules are internally initialized.
 
 #### RestoreSystemProperties
 The [RestoreSystemProperties](../junit-extensions/src/main/java/org/codice/junit/rules/RestoreSystemProperties.java) provides a Java version of the Spock annotation which when defined as a JUnit rule will automatically reset the system properties to their initial values after each tests.
@@ -17,7 +49,7 @@ The [RestoreSystemProperties](../junit-extensions/src/main/java/org/codice/junit
 ```
 
 #### ClearInterruptions
-The [ClearInterruptions](../junit-extensions/src/main/java/org/codice/junit/rules/ClearInterruptions.java) provides a Java version of the Spock annotation which when defined as a JUnit rule will clear interruption states from the current thread after testing. For example:
+The [ClearInterruptions](../junit-extensions/src/main/java/org/codice/junit/rules/ClearInterruptions.java) provides a Java version of the Spock annotation which when defined as a JUnit rule will clear interruption state from the current thread after testing. For example:
 ```
   public class MyTest {
     @Rule public final ClearInterruptions clearInterruptions = new ClearInterruptions();
@@ -33,6 +65,88 @@ The [ClearInterruptions](../junit-extensions/src/main/java/org/codice/junit/rule
     }
   }
 ```
+
+#### MethodRuleChain
+The [MethodRuleChain](../junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleChain.java) provides a JUnit4 rule that can be used to create a controlled chain of method rules when the order they are processed is important.
+
+```
+  public class MyTest {
+    @Rule public final MethodRuleChain chain = 
+      MethodRuleChain
+        .outer(new RestoreSystemProperties())
+        .around(new ClearInterruptions());
+
+    @Test
+    public void testSomething() throws Exception {
+      System.setProperty("ddf.home", "some new location");
+      final MyClass obj = new MyClass(some);
+      
+      obj.doSomething();
+    }
+  }
+```
+
+### JUnit Method Rules
+
+#### RestoreSystemProperties
+The [RestoreSystemProperties](../junit-extensions/src/main/java/org/codice/junit/RestoreSystemProperties.java) annotation can be used in conjunction with the MethodRuleAnnotationProcessor JUnit method rule to indicate all methods of a test class or specific ones where system properties should automatically be reset to their initial values after testing.
+
+#### ClearInterruptions
+The [ClearInterruptions](../junit-extensions/src/main/java/org/codice/junit/ClearInterruptions.java) annotation can be used in conjunction with the MethodRuleAnnotationProcessor JUnit method rule to indicate all methods of a test class or specific ones where the interruption state from the current thread should automatically be cleared after testing.
+
+### JUnit Test Runners
+
+#### MethodRuleAnnotationProcessor
+The [MethodRuleAnnotationRunner](../junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java) provides a JUnit4 test runner that supports annotation-based method rules similar support to Spock extensions by allowing specification of simple JUnit method rules via the meta-annotation [ExtensionMethodRuleAnnotation](../junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java).
+
+New annotations created referencing another JUnit method rule can be used to annotate JUnit test class when the method rule should apply to all tests in that class. These annotations can also be used to annotate a particular test method if the method rule should only apply to that test method.
+
+The order these new annotations are defined in will dictate the order they will be applied from outermost to innermost.
+
+Method rules referenced in this manner will not retain any states from one test method to the next as they will be re-instantiated each time. The method rule class must define either a public constructor with a single argument of the same annotation type as the annotation that is annotated with the meta-annotation [ExtensionMethodRuleAnnotation](../junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java) or a public default constructor. Defining a constructor with the annotation as a parameter allows customization of the method rule using your own annotation.
+
+```
+  @RestoreSystemProperties // will apply to each test methods
+  @RunWith(MethodRuleAnnotationRunner.class)
+  public class MyTest {
+    @ClearInterruptions // will only apply to this test method
+    @Test
+    public void testSomething() throws Exception {
+    }
+
+    @Test
+    public void testSomethingElse() throws Exception {
+    }
+  }
+```
+
+Example of a method rule annotation that can be customized:
+
+```
+public MyMethodRule implements MethodRule {
+  private final long timeout;
+  
+  public MyMethodRule(MyAnnotation annotation) {
+    this.timeout = annotation.timeout();  
+  }
+  
+  @Override
+  public Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
+    ...
+  }
+}
+
+@ExtensionMethodRuleAnnotation(MyMethodRule.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface MyAnnotation {
+  long timeout();
+}
+```
+
+The advantage of using the test runner [MethodRuleAnnotationRunner](../junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java) over the method rule [MethodRuleAnnotationProcessor](../junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java) is that it guarantees that all annotation-based rules will be considered outermost compared to any rules defined within the test class whereas the processor cannot guarantee that since it is at the mercy of JUnit in terms of how the rules are internally initialized.
 
 #### Definalizer
 The [Definalizer JUnit test runner](../junit-extensions/src/main/java/org/codice/junit/DeFinalizer.java) is designed as a generic proxy test runner for another JUnit test runner by indirectly instantiating that runner in order to add support for de-finalizing (i.e. removing the final constraint) 3rd party Java classes that need to be mocked or stubbed during testing. 

--- a/docs/spock-extensions.md
+++ b/docs/spock-extensions.md
@@ -1,4 +1,4 @@
-#Spock Extensions
+##Spock Extensions
 
 #### @ClearInterruptions
 The [`@ClearInterruptions`](../spock-extensions/src/main/groovy/org/codice/spock/ClearInterruptions.groovy) annotation can be used to clear interruption states from the current thread after testing. For example:

--- a/docs/spock-extensions.md
+++ b/docs/spock-extensions.md
@@ -1,4 +1,4 @@
-##Spock Extensions
+## Spock Extensions
 
 #### @ClearInterruptions
 The [`@ClearInterruptions`](../spock-extensions/src/main/groovy/org/codice/spock/ClearInterruptions.groovy) annotation can be used to clear interruption states from the current thread after testing. For example:

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -23,33 +23,23 @@
         <version>0.4-SNAPSHOT</version>
     </parent>
 
-    <name>Codice Test :: JUnit Extensions</name>
-    <artifactId>junit-extensions</artifactId>
+    <name>Codice Test :: Internal</name>
+    <artifactId>internal</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.codice.test</groupId>
-            <artifactId>internal</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
         </dependency>
 
         <dependency>
@@ -86,17 +76,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.38</minimum>
+                                            <minimum>0.57</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.63</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.41</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/internal/src/main/java/org/codice/test/commons/ReflectionUtils.java
+++ b/internal/src/main/java/org/codice/test/commons/ReflectionUtils.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.test.commons;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.ArrayUtils;
+
+/** Sets of reflection useful functions. */
+public class ReflectionUtils {
+  /**
+   * Gets the annotations that are <em>associated</em> with the specified element and the meta
+   * annotations recursively contained in annotations that are <em>associated</em> with the
+   * specified element.
+   *
+   * @param <A> the type of annotation to find
+   * @param element the annotated element to find all annotations and meta annotations for
+   * @param annotation the type of annotations to find
+   * @return a stream of all annotation entries (i.e. annotations and meta annotations) of the
+   *     specified types found in the order they are defined
+   */
+  public static <A extends Annotation> Stream<AnnotationEntry<A>> annotationsByType(
+      AnnotatedElement element, Class<A> annotation) {
+    final Map<Annotation, Annotation> visited = new IdentityHashMap<>();
+
+    return Stream.of(element.getAnnotations())
+        .flatMap(a -> ReflectionUtils.annotationsByTypes(visited, element, null, a))
+        .filter(ae -> ae.instanceOf(annotation))
+        .map(AnnotationEntry.class::<A>cast);
+  }
+
+  /**
+   * Gets the annotations that are <em>associated</em> with the specified element and the meta
+   * annotations recursively contained in annotations that are <em>associated</em> with the
+   * specified element.
+   *
+   * @param element the annotated element to find all annotations and meta annotations for
+   * @param annotations the types of annotations to find
+   * @return a stream of all annotation entries (i.e. annotations and meta annotations) of the
+   *     specified types found in the order they are defined
+   */
+  public static Stream<AnnotationEntry<?>> annotationsByTypes(
+      AnnotatedElement element, Class<? extends Annotation>... annotations) {
+    final Map<Annotation, Annotation> visited = new IdentityHashMap<>();
+
+    return Stream.of(element.getAnnotations())
+        .flatMap(a -> ReflectionUtils.annotationsByTypes(visited, element, null, a))
+        .filter(ae -> ae.instanceOf(annotations));
+  }
+
+  /**
+   * Gets the annotations that are <em>associated</em> with the specified elements.
+   *
+   * @param <A> the type of annotation to search for
+   * @param annotation the annotation to find
+   * @param elements the annotated elements to find all annotations for
+   * @return a stream of all annotations of the specified type found on all specified elements
+   */
+  public static <A extends Annotation> Stream<A> annotationsByType(
+      Class<A> annotation, AnnotatedElement... elements) {
+    return Stream.of(elements).map(e -> e.getAnnotationsByType(annotation)).flatMap(Stream::of);
+  }
+
+  /**
+   * Gets all members of a given type annotated with the specified annotation.
+   *
+   * @param <T> the type of members to retrieve (either {@link Field}, {@link Method}, or {@link
+   *     Constructor})
+   * @param <A> the type of annotation to search for
+   * @param type the type of members to retrieve
+   * @param clazz the class from which to find all annotated members
+   * @param annotation the annotation for which to find all members
+   * @param up <code>true</code> to look up the class hierarchy; <code>false</code> to only look at
+   *     the specified class level
+   * @return a non-<code>null</code> map in the provided order for all annotated members with their
+   *     found annotations
+   * @throws IllegalArgumentException if <code>type</code> is not {@link Field}, {@link Method}, or
+   *     {@link Constructor}
+   */
+  public static <T extends Member, A extends Annotation>
+      Map<T, A[]> getAllAnnotationsForMembersAnnotatedWith(
+          Class<T> type, Class<?> clazz, Class<A> annotation, boolean up) {
+    final LinkedList<Class<?>> classes = new LinkedList<>();
+    Class<?> currentClass = clazz;
+
+    if (up) {
+      while (currentClass != null) {
+        classes.push(currentClass);
+        currentClass = currentClass.getSuperclass();
+      }
+    } else {
+      classes.push(currentClass);
+    }
+    final Map<T, A[]> members = new LinkedHashMap<>(12);
+
+    while (!classes.isEmpty()) {
+      currentClass = classes.pop();
+      for (final T m : ReflectionUtils.getDeclaredMembers(type, currentClass)) {
+        if (m instanceof AnnotatedElement) {
+          final A[] as = ((AnnotatedElement) m).getAnnotationsByType(annotation);
+
+          if (as.length > 0) {
+            members.put(m, as);
+          }
+        }
+      }
+    }
+    return members;
+  }
+
+  /**
+   * Gets all methods of a given type annotated with the specified annotation.
+   *
+   * @param <A> the type of annotation to search for
+   * @param clazz the class from which to find all annotated methods
+   * @param annotation the annotation for which to find all methods
+   * @param up <code>true</code> to look up the class hierarchy; <code>false</code> to only look at
+   *     the specified class level
+   * @return a non-<code>null</code> map in the provided order for all annotated methods with their
+   *     found annotations
+   */
+  public static <A extends Annotation> Map<Method, A[]> getAllAnnotationsForMethodsAnnotatedWith(
+      Class<?> clazz, Class<A> annotation, boolean up) {
+    return ReflectionUtils.getAllAnnotationsForMembersAnnotatedWith(
+        Method.class, clazz, annotation, up);
+  }
+
+  /**
+   * Gets the declared members of the given type from the specified class.
+   *
+   * @author paouelle
+   * @param <T> the type of member
+   * @param type the type of members to retrieve
+   * @param clazz the class from which to retrieve the members
+   * @return the non-<code>null</code> members of the given type from the specified class
+   * @throws IllegalArgumentException if <code>type</code> is not {@link Field}, {@link Method}, or
+   *     {@link Constructor}
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends Member> T[] getDeclaredMembers(Class<T> type, Class<?> clazz) {
+    if (type == Field.class) {
+      return (T[]) clazz.getDeclaredFields();
+    } else if (type == Method.class) {
+      return (T[]) clazz.getDeclaredMethods();
+    } else if (type == Constructor.class) {
+      return (T[]) clazz.getDeclaredConstructors();
+    } else {
+      throw new IllegalArgumentException("invalid member class: " + type.getName());
+    }
+  }
+
+  /**
+   * Represents an annotation or a meta annotation found.
+   *
+   * @param <A> the type of annotation
+   */
+  public static class AnnotationEntry<A extends Annotation> {
+    private final AnnotatedElement annotatedElement;
+    @Nullable private final Annotation enclosingAnnotation;
+    private final A annotation;
+
+    AnnotationEntry(
+        AnnotatedElement annotatedElement, Annotation enclosingAnnotation, A annotation) {
+      this.annotatedElement = annotatedElement;
+      this.enclosingAnnotation = enclosingAnnotation;
+      this.annotation = annotation;
+    }
+
+    /**
+     * Checks if this represents a meta annotation.
+     *
+     * @return <code>true</code> if this represents a meta annotation; <code>false</code> otherwise
+     */
+    public boolean isMetaAnnotation() {
+      return enclosingAnnotation != null;
+    }
+
+    /**
+     * Gets the element that was annotated. This will be either the direct element where the
+     * annotation was found or in the case of a meta annotation, it will be the element where an
+     * annotation was found that recursively included a meta annotation.
+     *
+     * @return the element that was annotated
+     */
+    public AnnotatedElement getAnnotatedElement() {
+      return annotatedElement;
+    }
+
+    /**
+     * Gets the immediate annotation where this annotation was found if this represents a meta
+     * annotation.
+     *
+     * @return the immediate annotation where this meta annotation was found or <code>null</code> if
+     *     this is not a meta annotation
+     */
+    @Nullable
+    public Annotation getEnclosingAnnotation() {
+      return enclosingAnnotation;
+    }
+
+    /**
+     * Gets the annotation that was found.
+     *
+     * @return the annotation that was found
+     */
+    public A getAnnotation() {
+      return annotation;
+    }
+
+    /**
+     * Gets the classloader associated with the element where the annotation was defined. For normal
+     * annotations, this will be the classloader associated with the annotated element (i.e. the
+     * class or the class defining the annotated method, field, or constructor). For meta
+     * annotations, this will be the classloader associated with the enclosing annotation class.
+     *
+     * @return the classloader associated with the element where the annotation was defined or
+     *     <code>null</code> if unable to determine
+     */
+    @Nullable
+    public ClassLoader getClassLoader() {
+      final Class<?> clazz;
+
+      if (isMetaAnnotation()) {
+        clazz = enclosingAnnotation.annotationType();
+      } else if (annotatedElement instanceof Class) {
+        clazz = (Class) annotatedElement;
+      } else if (annotatedElement instanceof Field) {
+        clazz = ((Field) annotatedElement).getDeclaringClass();
+      } else if (annotatedElement instanceof Method) {
+        clazz = ((Method) annotatedElement).getDeclaringClass();
+      } else if (annotatedElement instanceof Constructor) {
+        clazz = ((Constructor) annotatedElement).getDeclaringClass();
+      } else {
+        return null;
+      }
+      return clazz.getClassLoader();
+    }
+
+    @Override
+    public String toString() {
+      if (isMetaAnnotation()) {
+        return annotation
+            + " enclosed in "
+            + enclosingAnnotation
+            + " and located in "
+            + annotatedElement;
+      }
+      return annotation + " located in " + annotatedElement;
+    }
+
+    boolean instanceOf(Class<? extends Annotation> annotation) {
+      return this.annotation.annotationType().equals(annotation);
+    }
+
+    boolean instanceOf(Class<? extends Annotation>... annotations) {
+      return ArrayUtils.contains(annotations, annotation.annotationType());
+    }
+  }
+
+  private static Stream<AnnotationEntry<?>> annotationsByTypes(
+      Map<Annotation, Annotation> visited,
+      AnnotatedElement element,
+      @Nullable Annotation enclosingAnnotation,
+      Annotation annotation) {
+    if (visited.putIfAbsent(annotation, annotation) != null) {
+      return Stream.empty();
+    }
+    return Stream.concat(
+        Stream.of(new AnnotationEntry<>(element, enclosingAnnotation, annotation)),
+        Stream.of(annotation.annotationType().getAnnotations())
+            .flatMap(a -> ReflectionUtils.annotationsByTypes(visited, element, annotation, a)));
+  }
+}

--- a/junit-extensions/pom.xml
+++ b/junit-extensions/pom.xml
@@ -91,12 +91,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.29</minimum>
+                                            <minimum>0.27</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/junit-extensions/src/main/java/org/codice/junit/ClearInterruptions.java
+++ b/junit-extensions/src/main/java/org/codice/junit/ClearInterruptions.java
@@ -19,12 +19,12 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.codice.junit.rules.MethodRuleAnnotationProcessor;
 
 /**
  * The <code>ClearInterruptions</code> annotation can be used in conjunction with the {@link
- * MethodRuleAnnotationProcessor} JUnit method rule to clear any interruption states after a
- * particular test method.
+ * org.codice.junit.MethodRuleAnnotationRunner} JUnit test runner or the {@link
+ * org.codice.junit.rules.MethodRuleAnnotationProcessor} JUnit method rule to clear any interruption
+ * states after a particular test method.
  *
  * <p>Applying this annotation to a JUnit test class has the same effect as applying it to all its
  * test methods.

--- a/junit-extensions/src/main/java/org/codice/junit/ClearInterruptions.java
+++ b/junit-extensions/src/main/java/org/codice/junit/ClearInterruptions.java
@@ -19,27 +19,19 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
 
 /**
- * This annotation is used to indicate to the {@link DeFinalizer} test runner which classes or
- * packages should be definalized.
+ * The <code>ClearInterruptions</code> annotation can be used in conjunction with the {@link
+ * MethodRuleAnnotationProcessor} JUnit method rule to clear any interruption states after a
+ * particular test method.
+ *
+ * <p>Applying this annotation to a JUnit test class has the same effect as applying it to all its
+ * test methods.
  */
-@Target(ElementType.TYPE)
+@ExtensionMethodRuleAnnotation(org.codice.junit.rules.ClearInterruptions.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
-public @interface DeFinalize {
-  /**
-   * Specifies the classes to de-finalize.
-   *
-   * @return the classes to de-finalize
-   */
-  public Class<?>[] value() default {};
-
-  /**
-   * Specifies the packages to de-finalize.
-   *
-   * @return the fully qualified names for the packages to de-finalize
-   */
-  public String[] packages() default {};
-}
+public @interface ClearInterruptions {}

--- a/junit-extensions/src/main/java/org/codice/junit/DeFinalizeWith.java
+++ b/junit-extensions/src/main/java/org/codice/junit/DeFinalizeWith.java
@@ -13,6 +13,7 @@
  */
 package org.codice.junit;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -28,11 +29,11 @@ import org.junit.runner.Runner;
  * org.spockframework.runtime.Sputnik} test runner will be used if the class or the Spock's
  * specification is not annotated with this annotation.
  */
-@Inherited
-@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
 public @interface DeFinalizeWith {
-
   /** @return a runner class (must have a constructor that takes a single class to run) */
   public Class<? extends Runner> value();
 }

--- a/junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java
+++ b/junit-extensions/src/main/java/org/codice/junit/ExtensionMethodRuleAnnotation.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
+import org.junit.rules.MethodRule;
+
+/**
+ * Defines a meta annotation which enables the developer to create a new annotation referencing a
+ * JUnit method rule that can be automatically plugged into the JUnit test class as long as the test
+ * class is running with the {@link MethodRuleAnnotationRunner} test runner or the {@link
+ * MethodRuleAnnotationProcessor} method rule has been defined in the test class.
+ *
+ * <p>It is possible to annotate the test class if the method rule should apply to all tests in that
+ * class or a particular test method if the method rule should only apply to that test method.
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface ExtensionMethodRuleAnnotation {
+  /**
+   * Specifies the method rules to be plugged into the JUnit test class. The method rule class must
+   * define either a public constructor with a single argument of the same annotation type as the
+   * annotation that is annotated with this meta-annotation or a public default constructor.
+   * Defining a constructor with the annotation as a parameter allows customization of the method
+   * rule using your own annotation.
+   *
+   * @return the class for the method rule to be plugged into the JUnit test class
+   */
+  Class<? extends MethodRule> value();
+}

--- a/junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java
+++ b/junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.junit;
+
+import java.util.List;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
+import org.junit.rules.MethodRule;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * The <code>MethodRuleAnnotationRunner</code> class defines a JUnit4 test runner that allows
+ * specification of method rules via the meta-annotation {@link ExtensionMethodRuleAnnotation}.
+ *
+ * <p>The order annotations containing the meta-annotation {@link ExtensionMethodRuleAnnotation} are
+ * provided will dictate the order they will be applied from outermost to innermost.
+ *
+ * <p>It is possible to annotate the test class if the method rule should apply to all tests in that
+ * class or a particular test method if the method rule should only apply to that test method.
+ *
+ * <p>The advantage of using the test runner {@link MethodRuleAnnotationRunner} over the method rule
+ * {@link MethodRuleAnnotationProcessor} is that it guarantees that all annotation-based rules will
+ * be considered outermost compared to any rules defined within the test class whereas the processor
+ * cannot guarantee that since it is at the mercy of JUnit in terms of how these are internally
+ * initialized.
+ */
+public class MethodRuleAnnotationRunner extends BlockJUnit4ClassRunner {
+  /**
+   * Creates a new annotation-based test runner for the specified test class.
+   *
+   * @param clazz the test class to run
+   * @throws InitializationError if the test class is malformed
+   */
+  public MethodRuleAnnotationRunner(Class<?> clazz) throws InitializationError {
+    super(clazz);
+  }
+
+  @Override
+  protected List<MethodRule> rules(Object target) {
+    final List<MethodRule> rules = super.rules(target);
+
+    if (rules
+        .stream()
+        .filter(MethodRuleAnnotationProcessor.class::isInstance)
+        .findAny()
+        .isPresent()) {
+      throw new IllegalStateException(
+          "a method rule annotation processor is already defined in "
+              + target.getClass().getName());
+    }
+    // by adding it last, the annotation processor method rule will have higher priority and be
+    // the outmost rule
+    rules.add(new MethodRuleAnnotationProcessor());
+    return rules;
+  }
+}

--- a/junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java
+++ b/junit-extensions/src/main/java/org/codice/junit/MethodRuleAnnotationRunner.java
@@ -48,20 +48,6 @@ public class MethodRuleAnnotationRunner extends BlockJUnit4ClassRunner {
 
   @Override
   protected List<MethodRule> rules(Object target) {
-    final List<MethodRule> rules = super.rules(target);
-
-    if (rules
-        .stream()
-        .filter(MethodRuleAnnotationProcessor.class::isInstance)
-        .findAny()
-        .isPresent()) {
-      throw new IllegalStateException(
-          "a method rule annotation processor is already defined in "
-              + target.getClass().getName());
-    }
-    // by adding it last, the annotation processor method rule will have higher priority and be
-    // the outmost rule
-    rules.add(new MethodRuleAnnotationProcessor());
-    return rules;
+    return MethodRuleAnnotationProcessor.around(super.rules(target));
   }
 }

--- a/junit-extensions/src/main/java/org/codice/junit/RestoreSystemProperties.java
+++ b/junit-extensions/src/main/java/org/codice/junit/RestoreSystemProperties.java
@@ -19,27 +19,19 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
 
 /**
- * This annotation is used to indicate to the {@link DeFinalizer} test runner which classes or
- * packages should be definalized.
+ * The <code>RestoreSystemProperties</code> annotation can be used in conjunction with the {@link
+ * MethodRuleAnnotationProcessor} JUnit method rule to restore any changes made to system properties
+ * by a given test method.
+ *
+ * <p>Applying this annotation to a JUnit test class has the same effect as applying it to all its
+ * test methods.
  */
-@Target(ElementType.TYPE)
+@ExtensionMethodRuleAnnotation(org.codice.junit.rules.RestoreSystemProperties.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
-public @interface DeFinalize {
-  /**
-   * Specifies the classes to de-finalize.
-   *
-   * @return the classes to de-finalize
-   */
-  public Class<?>[] value() default {};
-
-  /**
-   * Specifies the packages to de-finalize.
-   *
-   * @return the fully qualified names for the packages to de-finalize
-   */
-  public String[] packages() default {};
-}
+public @interface RestoreSystemProperties {}

--- a/junit-extensions/src/main/java/org/codice/junit/RestoreSystemProperties.java
+++ b/junit-extensions/src/main/java/org/codice/junit/RestoreSystemProperties.java
@@ -19,12 +19,12 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.codice.junit.rules.MethodRuleAnnotationProcessor;
 
 /**
  * The <code>RestoreSystemProperties</code> annotation can be used in conjunction with the {@link
- * MethodRuleAnnotationProcessor} JUnit method rule to restore any changes made to system properties
- * by a given test method.
+ * org.codice.junit.MethodRuleAnnotationRunner} JUnit test runner or the {@link
+ * org.codice.junit.rules.MethodRuleAnnotationProcessor} JUnit method rule to restore any changes
+ * made to system properties by a given test method.
  *
  * <p>Applying this annotation to a JUnit test class has the same effect as applying it to all its
  * test methods.

--- a/junit-extensions/src/main/java/org/codice/junit/parameterized/MethodRuleAnnotationRunnerWithParameters.java
+++ b/junit-extensions/src/main/java/org/codice/junit/parameterized/MethodRuleAnnotationRunnerWithParameters.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.junit.parameterized;
+
+import java.util.List;
+import org.codice.junit.ExtensionMethodRuleAnnotation;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParameters;
+import org.junit.runners.parameterized.TestWithParameters;
+
+/**
+ * The <code>MethodRuleAnnotationRunnerWithParameters</code> class defines a JUnit4 test runner that allows
+ * specification of method rules via the meta-annotation {@link ExtensionMethodRuleAnnotation} for
+ * parameterized tests. This class should not be referenced directly but instead used with
+ * <code@RunWith(Parameterized.class)</code> using a
+ * <code>@UseParametersRunnerFactory(MethodRuleAnnotationRunnerWithParametersFactory.class)</code>
+ * annotation which will indirectly instantiate this runner for each of the parameterized tests.
+ *
+ * <p>The order annotations containing the meta-annotation {@link ExtensionMethodRuleAnnotation} are
+ * provided will dictate the order they will be applied from outermost to innermost.
+ *
+ * <p>It is possible to annotate the test class if the method rule should apply to all tests in that
+ * class or a particular test method if the method rule should only apply to that test method.
+ *
+ * <p>The advantage of using the test runner {@link MethodRuleAnnotationRunnerWithParameters} over
+ * the method rule {@link MethodRuleAnnotationProcessor} is that it guarantees that all
+ * annotation-based rules will be considered outermost compared to any rules defined within the test
+ * class whereas the processor cannot guarantee that since it is at the mercy of JUnit in terms of
+ * how these are internally initialized.
+ */
+public class MethodRuleAnnotationRunnerWithParameters extends BlockJUnit4ClassRunnerWithParameters {
+  /**
+   * Creates a new annotation-based test runner for the specified test class.
+   *
+   * @param test the test with parameters information
+   * @throws InitializationError if the test class is malformed
+   */
+  public MethodRuleAnnotationRunnerWithParameters(TestWithParameters test)
+      throws InitializationError {
+    super(test);
+  }
+
+  @Override
+  protected List<MethodRule> rules(Object target) {
+    return MethodRuleAnnotationProcessor.around(super.rules(target));
+  }
+}

--- a/junit-extensions/src/main/java/org/codice/junit/parameterized/MethodRuleAnnotationRunnerWithParametersFactory.java
+++ b/junit-extensions/src/main/java/org/codice/junit/parameterized/MethodRuleAnnotationRunnerWithParametersFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.junit.parameterized;
+
+import org.codice.junit.ExtensionMethodRuleAnnotation;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
+import org.junit.runner.Runner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.parameterized.ParametersRunnerFactory;
+import org.junit.runners.parameterized.TestWithParameters;
+
+/**
+ * The <code>MethodRuleAnnotationRunnerWithParametersFactory</code> class defines a JUnit4 parameter
+ * factory to create test runners that allows specification of method rules via the meta-annotation
+ * {@link ExtensionMethodRuleAnnotation}. This class should be used when running tests with
+ * <code@RunWith(Parameterized.class)</code> using a
+ * <code>@UseParametersRunnerFactory(MethodRuleAnnotationRunnerWithParametersFactory.class)</code>
+ * annotation.
+ *
+ * <p>The order annotations containing the meta-annotation {@link ExtensionMethodRuleAnnotation} are
+ * provided will dictate the order they will be applied from outermost to innermost.
+ *
+ * <p>It is possible to annotate the test class if the method rule should apply to all tests in that
+ * class or a particular test method if the method rule should only apply to that test method.
+ *
+ * <p>The advantage of using the test runner {@link MethodRuleAnnotationRunnerWithParameters} over
+ * the method rule {@link MethodRuleAnnotationProcessor} is that it guarantees that all
+ * annotation-based rules will be considered outermost compared to any rules defined within the test
+ * class whereas the processor cannot guarantee that since it is at the mercy of JUnit in terms of
+ * how these are internally initialized.
+ */
+public class MethodRuleAnnotationRunnerWithParametersFactory implements ParametersRunnerFactory {
+  @Override
+  public Runner createRunnerForTestWithParameters(TestWithParameters test)
+      throws InitializationError {
+    return new MethodRuleAnnotationRunnerWithParameters(test);
+  }
+}

--- a/junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java
+++ b/junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.junit.rules;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.codice.junit.ExtensionMethodRuleAnnotation;
+import org.codice.test.commons.ReflectionUtils;
+import org.codice.test.commons.ReflectionUtils.AnnotationEntry;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * The <code>MethodRuleAnnotationProcessor</code> class provides a JUnit4 method rule that allows
+ * specification of method rules via the meta-annotation {@link ExtensionMethodRuleAnnotation}.
+ *
+ * <p>The order annotations containing the meta-annotation {@link ExtensionMethodRuleAnnotation} are
+ * provided will dictate the order they will be applied from outermost to innermost.
+ *
+ * <p>It is possible to annotate the test class if the method rule should apply to all tests in that
+ * class or a particular test method if the method rule should only apply to that test method.
+ *
+ * <p>The advantage of using the test runner {@link org.codice.junit.MethodRuleAnnotationRunner}
+ * over the method rule {@link MethodRuleAnnotationProcessor} is that it guarantees that all
+ * annotation-based rules will be considered outermost compared to any rules defined within the test
+ * class whereas the processor cannot guarantee that since it is at the mercy of JUnit in terms of
+ * how these are internally initialized.
+ */
+public class MethodRuleAnnotationProcessor implements MethodRule {
+  @Override
+  public Statement apply(Statement base, FrameworkMethod method, Object target) {
+    final List<MethodRule> rules =
+        Stream.concat(
+                ReflectionUtils.annotationsByType(
+                    target.getClass(), ExtensionMethodRuleAnnotation.class),
+                ReflectionUtils.annotationsByType(
+                    method.getMethod(), ExtensionMethodRuleAnnotation.class))
+            .map(MethodRuleAnnotationProcessor::newInstance)
+            .collect(Collectors.toList());
+
+    for (final ListIterator<MethodRule> i = rules.listIterator(rules.size()); i.hasPrevious(); ) {
+      base = i.previous().apply(base, method, target);
+    }
+    return base;
+  }
+
+  private static MethodRule newInstance(AnnotationEntry<ExtensionMethodRuleAnnotation> entry) {
+    final Class<? extends MethodRule> clazz = entry.getAnnotation().value();
+
+    try {
+      return MethodRuleAnnotationProcessor.newInstance(clazz, entry.getEnclosingAnnotation());
+    } catch (IllegalAccessException | InstantiationException e) {
+      throw new AssertionError("failed to instantiate method rule: " + clazz.getName(), e);
+    } catch (InvocationTargetException e) {
+      throw new AssertionError(
+          "failed to instantiate method rule: " + clazz.getName(), e.getTargetException());
+    }
+  }
+
+  private static MethodRule newInstance(Class<? extends MethodRule> clazz, Annotation enclosing)
+      throws InvocationTargetException, InstantiationException, IllegalAccessException {
+    try {
+      // first check if a constructor that can receive the annotation exist
+      return clazz.getConstructor(enclosing.annotationType()).newInstance(enclosing);
+    } catch (NoSuchMethodException e) { // ignore and continue with default ctor
+      return clazz.newInstance();
+    }
+  }
+}

--- a/junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java
+++ b/junit-extensions/src/main/java/org/codice/junit/rules/MethodRuleAnnotationProcessor.java
@@ -15,6 +15,7 @@ package org.codice.junit.rules;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
@@ -43,6 +44,34 @@ import org.junit.runners.model.Statement;
  * how these are internally initialized.
  */
 public class MethodRuleAnnotationProcessor implements MethodRule {
+  /**
+   * Adds a method rule annotation processor around a set of other rules. If one is already defined,
+   * it is promoted to the bottom of the list otherwise a new one is added at the bottom of the
+   * list.
+   *
+   * <p>By adding it last, the annotation processor method rule will have higher priority and be the
+   * outer most rule.
+   *
+   * @param rules the rules in which to adda method rule annotation processor around
+   * @return the updated list of rules
+   */
+  public static List<MethodRule> around(List<MethodRule> rules) {
+    MethodRule found = null;
+
+    for (final Iterator<MethodRule> i = rules.iterator(); i.hasNext(); ) {
+      final MethodRule r = i.next();
+
+      if (r instanceof MethodRuleAnnotationProcessor) {
+        found = r;
+        i.remove();
+      }
+    }
+    // by adding it last, the annotation processor method rule will have higher priority and be
+    // the outer most rule
+    rules.add((found != null) ? found : new MethodRuleAnnotationProcessor());
+    return rules;
+  }
+
   @Override
   public Statement apply(Statement base, FrameworkMethod method, Object target) {
     final List<MethodRule> rules =

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.codice.test</groupId>
@@ -346,6 +348,7 @@
 
     <modules>
         <module>spock-all</module>
+        <module>internal</module>
         <module>junit-extensions</module>
         <module>hamcrest-extensions</module>
         <module>mockito-extensions</module>

--- a/spock-extensions/src/main/groovy/org/codice/spock/ClearInterruptions.groovy
+++ b/spock-extensions/src/main/groovy/org/codice/spock/ClearInterruptions.groovy
@@ -11,15 +11,17 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.spock;
+package org.codice.spock
 
+import org.codice.spock.builtin.ClearInterruptionsExtension
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.Documented
 import java.lang.annotation.ElementType
 import java.lang.annotation.Inherited
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
-import org.codice.spock.builtin.ClearInterruptionsExtension
-import org.spockframework.runtime.extension.ExtensionAnnotation
 
 /**
  * The <code>ClearInterruptions</code> annotation can be used to clear any interruption states from
@@ -28,8 +30,9 @@ import org.spockframework.runtime.extension.ExtensionAnnotation
  * <p>Applying this annotation to a Spock specification class has the same effect as applying it to all
  * its feature methods.
  */
-@Inherited
 @ExtensionAnnotation(ClearInterruptionsExtension.class)
-@Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.TYPE, ElementType.METHOD])
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
 @interface ClearInterruptions {}

--- a/spock-extensions/src/main/groovy/org/codice/spock/Supplemental.groovy
+++ b/spock-extensions/src/main/groovy/org/codice/spock/Supplemental.groovy
@@ -16,12 +16,13 @@ package org.codice.spock
 import org.codice.spock.builtin.SupplementalExtension
 import org.spockframework.runtime.extension.ExtensionAnnotation
 
-import java.lang.annotation.*
+import java.lang.annotation.Documented
+import java.lang.annotation.ElementType
+import java.lang.annotation.Inherited
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
 
-@Inherited
-@ExtensionAnnotation(SupplementalExtension)
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
 /**
  * The <code>Supplemental</code> annotation can be added to any Spock specification class in order
  * to get additional methods added to specific classes while testing the specification.
@@ -69,4 +70,9 @@ import java.lang.annotation.*
  *       <p>Creates dummy values or stubs for the specified types.</li>
  * </ul>
  */
+@ExtensionAnnotation(SupplementalExtension)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
 public @interface Supplemental {}


### PR DESCRIPTION
### Description of the Change
Added support for annotation-based JUnit method rules.
Added annotations for existing ResetSystemProperties and ClearInterruptions method rules.
Also added place holder reflection utilities for upcoming PaxExam PR.

### Verification Process
Successful PR build

### Applicable Issues
Fixes: #24 