### PR TITLE
TEST-49 Fixes for dominion probe initialization on Windows

### DIFF
--- a/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/internal/DominionKarafDistributionBaseConfigurationOption.java
+++ b/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/internal/DominionKarafDistributionBaseConfigurationOption.java
@@ -14,7 +14,6 @@
 package org.codice.dominion.pax.exam.internal;
 
 import java.io.File;
-import org.codice.dominion.pax.exam.interpolate.PaxExamInterpolator;
 import org.ops4j.pax.exam.karaf.options.KarafDistributionBaseConfigurationOption;
 
 /**
@@ -23,11 +22,11 @@ import org.ops4j.pax.exam.karaf.options.KarafDistributionBaseConfigurationOption
  */
 public class DominionKarafDistributionBaseConfigurationOption
     extends KarafDistributionBaseConfigurationOption {
-  private final PaxExamInterpolator interpolator;
+  private final PaxExamDriverInterpolator interpolator;
   private final KarafDistributionBaseConfigurationOption config;
 
   DominionKarafDistributionBaseConfigurationOption(
-      PaxExamInterpolator interpolator, KarafDistributionBaseConfigurationOption config) {
+      PaxExamDriverInterpolator interpolator, KarafDistributionBaseConfigurationOption config) {
     // make sure to set all super attributes in case this option is later cloned as the base class
     // copy constructor access those directly
     super(config);

--- a/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/internal/PaxExamDriverInterpolator.java
+++ b/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/internal/PaxExamDriverInterpolator.java
@@ -124,23 +124,19 @@ public class PaxExamDriverInterpolator extends PaxExamInterpolator {
    */
   public Option[] getOptions() {
     return new Option[] {
-      // create a subclass of the system property option to delay the evaluation of the replacement
-      // map in order to collect all registered values
-      new SystemPropertyOption(Interpolator.REPLACEMENTS_KEY) {
+      // create a subclass of the system property option to delay the evaluation of the
+      // interpolation information to the very last minute. This will allow us to catch all
+      // replacement information and port allocated via interpolation of all annotations as these
+      // would be resolved and evaluated before PaxExam gets this information
+      new SystemPropertyOption(Interpolator.INFO_FILE_KEY) {
         @Override
         public String getValue() {
           initKaraf(); // make sure {karaf.XXXX} were initialized
-          return getReplacementsInfo();
-        }
-      },
-      // create a subclass of the system property option to delay the evaluation of the system
-      // port information to the very last minute. This will allow us to catch all port allocated
-      // via interpolation of all annotations as these would be resolved and evaluated before
-      // PaxExam gets this information
-      new SystemPropertyOption(Interpolator.PORTS_KEY) {
-        @Override
-        public String getValue() {
-          return getPortsInfo();
+          try {
+            return save(distribution.getUnpackDirectory()).getAbsolutePath();
+          } catch (IOException e) {
+            throw new InterpolationException("unable to save the interpolation information", e);
+          }
         }
       }
     };
@@ -163,7 +159,7 @@ public class PaxExamDriverInterpolator extends PaxExamInterpolator {
       this.distribution = distro;
       LOGGER.info(
           "Target folder for containers: {}",
-          distro.getUnpackDirectory().toPath().toAbsolutePath());
+          distro.getUnpackDirectory().getParentFile().toPath().toAbsolutePath());
     }
   }
 

--- a/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/options/extensions/InstallExtension.java
+++ b/dominion-pax-exam-driver/src/main/java/org/codice/dominion/pax/exam/options/extensions/InstallExtension.java
@@ -42,6 +42,11 @@ import org.ops4j.pax.exam.Option;
   artifact = {
     @MavenUrl(
       groupId = MavenUrl.AS_PROJECT,
+      artifactId = "dominion",
+      version = MavenUrl.AS_IN_PROJECT
+    ),
+    @MavenUrl(
+      groupId = MavenUrl.AS_PROJECT,
       artifactId = "dominion-pax-exam-invokers",
       version = MavenUrl.AS_IN_PROJECT
     ),

--- a/dominion-pax-exam/src/main/java/org/codice/dominion/pax/exam/interpolate/PaxExamInterpolator.java
+++ b/dominion-pax-exam/src/main/java/org/codice/dominion/pax/exam/interpolate/PaxExamInterpolator.java
@@ -13,6 +13,7 @@
  */
 package org.codice.dominion.pax.exam.interpolate;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.annotation.Nullable;
@@ -79,7 +80,7 @@ public class PaxExamInterpolator extends Interpolator {
    * @param testClass the current test class
    */
   public PaxExamInterpolator(Class<?> testClass) {
-    super(testClass, System.getProperties());
+    super(testClass, PaxExamInterpolator.getFileFromSystemProperties());
     this.karafHome = Paths.get(initFromReplacements("karaf.home"));
     LOGGER.debug(
         "PaxExamInterpolator({}, {}, {}) - karaf.home = {}", testClass, id, container, karafHome);
@@ -149,5 +150,16 @@ public class PaxExamInterpolator extends Interpolator {
   public Path getKarafEtc() {
     getKarafHome();
     return karafEtc;
+  }
+
+  private static File getFileFromSystemProperties() {
+    final String filename = System.getProperty(Interpolator.INFO_FILE_KEY);
+
+    if (filename == null) {
+      throw new ContainerNotStagedException(
+          "Unable to retrieved interpolation file from system property: "
+              + Interpolator.INFO_FILE_KEY);
+    }
+    return new File(filename);
   }
 }

--- a/dominion/src/main/java/org/codice/dominion/interpolate/Interpolator.java
+++ b/dominion/src/main/java/org/codice/dominion/interpolate/Interpolator.java
@@ -15,9 +15,15 @@ package org.codice.dominion.interpolate;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -41,8 +47,9 @@ public class Interpolator implements Closeable, StringLookup {
 
   public static final String DEFAULT_CONTAINER = "default";
 
-  public static final String REPLACEMENTS_KEY = "dominion.interpolator.replacements";
-  public static final String PORTS_KEY = "dominion.interpolator.ports";
+  public static final String INFO_FILE_KEY = "dominion.interpolator.info";
+  public static final String REPLACEMENTS_KEY = "replacements";
+  public static final String PORTS_KEY = "ports";
 
   private static final int BASE_PORT = 20000;
   private static final int BLOCK_SIZE = 20;
@@ -126,15 +133,22 @@ public class Interpolator implements Closeable, StringLookup {
   }
 
   /**
-   * Initializes a new interpolator with all the specified information already computed (typically
-   * from inside a container).
+   * Initializes a new interpolator with all interpolation information already computed and saved to
+   * the specified file (typically from inside a container).
    *
    * @param testClass the current test class
-   * @param properties properties from which to retrieve the replacement and port info
+   * @param file file from which to retrieve the interpolation info
    */
-  public Interpolator(Class<?> testClass, Properties properties) {
-    LOGGER.debug("Interpolator({}, Properties)", testClass);
+  public Interpolator(Class<?> testClass, File file) {
+    LOGGER.debug("Interpolator({}, {})", testClass, file);
     this.testClass = testClass;
+    final Properties properties = new Properties();
+
+    try (final Reader r = new BufferedReader(new FileReader(file))) {
+      properties.load(r);
+    } catch (IOException e) {
+      throw new ContainerNotStagedException("Unable to read interpolation file: " + file, e);
+    }
     try {
       this.replacements =
           new Gson().fromJson(properties.getProperty(Interpolator.REPLACEMENTS_KEY, ""), Map.class);
@@ -366,25 +380,28 @@ public class Interpolator implements Closeable, StringLookup {
   }
 
   /**
-   * Gets the current replacement information as a Json string suitable to rebuild an interpolator
-   * using the {@link #Interpolator(Class, Properties)} constructor.
+   * Saves the current interpolation information (i.e. replacement and port) to disk and get a file
+   * object where the information was saved. This is the same file that should be passed to the
+   * {@link #Interpolator(Class, File)} constructor inside the container to reload the information
+   * and initialize the interpolator.
    *
-   * @return a json string for the current set of replacement information
+   * @param root the root directory where to create the file
+   * @return the file where the information was saved
+   * @throws IOException if an I/O error occurs while saving the file
    */
-  public String getReplacementsInfo() {
-    return new Gson().toJson(replacements);
-  }
+  public File save(File root) throws IOException {
+    final File file = new File(root, "interpolation.json");
+    final Properties properties = new Properties();
+    final Gson gson = new Gson();
 
-  /**
-   * Gets the current port information as a Json string suitable to rebuild an interpolator using
-   * the {@link #Interpolator(Class, Properties)} constructor.
-   *
-   * @return a json string for the current set of port information
-   */
-  public String getPortsInfo() {
+    properties.put(Interpolator.REPLACEMENTS_KEY, gson.toJson(replacements));
     synchronized (ports) {
-      return new Gson().toJson(ports);
+      properties.put(Interpolator.PORTS_KEY, gson.toJson(ports));
     }
+    try (final Writer writer = new BufferedWriter((new FileWriter(file)))) {
+      properties.store(writer, "Created by dominion");
+    }
+    return file;
   }
 
   @Override


### PR DESCRIPTION
### Requirements
* Filling out the template is required. Any pull request that does not
include enough information to be reviewed in a timely manner may be
closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
This PR changes the way the interpolation information is passed between the driver and the probe. Instead of passing it as Json strings inside system properties it now passes it as Json strings inside a file on disk and passes the filename inside a system property.

The issue being addressed was caused by Karaf which improperly escapes/unescapes backslashes which creates problems for Gson as it is expecting to have backslashes escaped and they end up not being escaped anymore. By saving the information to a file, the strings are avoiding the escaping/unescaping done by Karaf on top of the one that is typically done by Properties files. It also has the advantages that as the information grows, we will no longer be limited by what can fit inside a system property.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed
version was selected
-->

### Benefits
<!--
What benefits will be realized by the code change?
-->

### Possible Drawbacks
<!--
What are the possible side-effects or negative impacts of the code change?
-->

### Verification Process
<!--
What process did you follow to verify that your change has the desired effects?
- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->
Successful build

### Applicable Issues
<!--
Enter applicable Issues here
-->
Fixes: #49 