### PR TITLE
Remove Windows Stages from Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,15 +128,6 @@ pipeline {
                         }
                     }
                 }
-                stage ('Windows') {
-                    agent { label 'server-2016-small' }
-                    steps {
-                        withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
-                              bat 'mvn install -B -DskipStatic=true -DskipTests=true %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
-                              bat 'mvn clean install -B -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET% %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
-                        }
-                    }
-                }
             }
         }
         stage('Full Build') {
@@ -174,14 +165,6 @@ pipeline {
                                     postStatusToHash("${jsonBlob}", "${GITHUB_USERNAME}", "${GITHUB_REPONAME}", "${env.PR_COMMIT}", "${GITHUB_TOKEN}")
                                 }
                             }
-                        }
-                    }
-                }
-                stage ('Windows') {
-                    agent { label 'server-2016-small'}
-                    steps {
-                        withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
-                              bat 'mvn clean install -B %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
                         }
                     }
                 }


### PR DESCRIPTION
### Description of the Change
Windows builds hang, preventing builds from continuing to execute. This removes Windows stages from the builds. This was already implemented in other Codice projects.

### Alternate Designs
Seeing if we can get Windows builds working again on infrastructure

### Benefits
Successful builds

### Possible Drawbacks
Confidence in Windows Builds.

### Verification Process
Successful builds completed

### Applicable Issues
Fixes: #54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/codice-test/55)
<!-- Reviewable:end -->
