### PR TITLE
BR-42 Upgrade to maven-latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           Restrict nightly builds to master branch, all others will be built on change only.
           Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
         */
-        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
+        pollSCM(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
     }
     environment {
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '
@@ -101,7 +101,7 @@ pipeline {
             parallel {
                 stage ('Linux') {
                     steps {
-                        withMaven(maven: 'Maven 3.5.4', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                        withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
                               sh 'mvn install -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                               sh 'mvn clean install -B -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         }
@@ -135,7 +135,7 @@ pipeline {
             parallel {
                 stage ('Linux') {
                     steps {
-                        withMaven(maven: 'Maven 3.5.4', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                        withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
 			    script {
                                 if (params.RELEASE == true) {
                                     sh "mvn -B -Dtag=${env.RELEASE_TAG} -DreleaseVersion=${env.RELEASE_VERSION} -DdevelopmentVersion=${env.NEXT_VERSION} release:prepare"
@@ -177,7 +177,7 @@ pipeline {
                         sh "git checkout ${env.RELEASE_TAG}"
                     }
                 }
-                withMaven(maven: 'Maven 3.5.4', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
                     withCredentials([string(credentialsId: 'sonarqube-token', variable: 'SONAR_TOKEN')]) {
                         script {
                             // If this build is not a pull request, run sonar scan. otherwise run incremental scan
@@ -249,7 +249,7 @@ pipeline {
                     }
                 }
 
-                withMaven(maven: 'Maven 3.5.3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
                     sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10 -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           Restrict nightly builds to master branch, all others will be built on change only.
           Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
         */
-        pollSCM(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
+        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
     }
     environment {
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '


### PR DESCRIPTION
### Requirements
* Filling out the template is required. Any pull request that does not
include enough information to be reviewed in a timely manner may be
closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
The maven version used in the pipeline has been changed from 3.5.x to maven-latest, which currently is 3.6.3.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed
version was selected
-->

### Benefits
This change ensures we are building with the most current version of Maven

### Possible Drawbacks

### Verification Process
The changes have been applied and tested from my fork of the code
http://jenkins.phx.connexta.com/service/jenkins/job/W.I.P./job/codice-testTM/job/master/

### Applicable Issues
